### PR TITLE
Add Travis and codecov support (via covr)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: r
+sudo: required
+
+# Choose your operating system(s) (default: linux)
+os:
+  - linux
+  - osx
+
+# Bioconductor-specific stuff. If targetting bioc-devel then need to use
+# "bioc_use_devel: true", otherwise remove or comment-out this line.
+# TODO: Should --timings be added to r_check_args to mimic BioC build machines?
+bioc_required: true
+bioc_use_devel: true
+# On CRAN all warnings are treated as errors; this is not true on Bioconductor.
+warnings_are_errors: false
+
+# Need this if also using covr to get code coverage
+r_github_packages:
+  - jimhester/covr
+after_success:
+  - Rscript -e 'covr::codecov()'
+
+# bsseq-specific stuff
+r_build_args: "--no-build-vignettes --no-manual"
+# TODO: Travis is reporting an error when checking the vignette, hence the
+# inclusion of --no-vignettes in r_check_args
+r_check_args: "--no-vignettes"# Must 'manually' install packages in SUGGESTS in order to run full tests
+r_binary_packages:
+  - RUnit
+bioc_packages:
+  - bsseqData
+  - BiocStyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ after_success:
 r_build_args: "--no-build-vignettes --no-manual"
 # TODO: Travis is reporting an error when checking the vignette, hence the
 # inclusion of --no-vignettes in r_check_args
-r_check_args: "--no-vignettes"# Must 'manually' install packages in SUGGESTS in order to run full tests
+r_check_args: "--no-vignettes"
+# Must 'manually' install packages in SUGGESTS in order to run full tests
 r_binary_packages:
   - RUnit
 bioc_packages:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bsseq
-Version: 1.5.6
+Version: 1.5.7
 Title: Analyze, manage and store bisulfite sequencing data
 Description: A collection of tools for analyzing and visualizing bisulfite
     sequencing data.

--- a/README.md
+++ b/README.md
@@ -7,4 +7,11 @@ biocLite(bsseq')
 ```
 
 ## R CMD check results
-Bioconductor: [Multiple platform build/check report](http://master.bioconductor.org/checkResults/devel/bioc-LATEST/bsseq/)
+
+## Software status
+
+| Resource:     | Bioconductor        | Travis CI     |
+| ------------- | ------------------- | ------------- |
+| _Platforms:_  | _Multiple_          | _Linux_       |
+| R CMD check   | <a href="http://bioconductor.org/checkResults/release/bioc-LATEST/bsseq/"><img border="0" src="http://bioconductor.org/shields/build/release/bioc/bsseq.svg" alt="Build status"></a> (release)</br><a href="http://bioconductor.org/checkResults/devel/bioc-LATEST/bsseq/"><img border="0" src="http://bioconductor.org/shields/build/devel/bioc/bsseq.svg" alt="Build status"></a> (devel) | <a href="https://travis-ci.org/kasperdanielhansen/bsseq"><img src="https://travis-ci.org/kasperdanielhansen/bsseq.svg" alt="Build status"></a> |
+| Test coverage |                     | <a href="https://codecov.io/github/kasperdanielhansen/bsseq?branch=master"><img src="https://codecov.io/github/kasperdanielhansen/bsseq/coverage.svg?branch=master" alt="Coverage Status"/></a>   |                  |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ This is the developer version of Bioconductor package [bsseq](http://bioconducto
 
 ```r
 source('http://bioconductor.org/biocLite.R')
-biocLite(bsseq')
+useDevel(TRUE)
+biocLite('bsseq')
 ```
 
 ## R CMD check results


### PR DESCRIPTION
This PR closes #5 by adding Travis builds to bsseq. It uses Travis's native R support to build on both linux and OSX with the devel branch of Bioconductor. Windows support will need to use another CI service and would be more work (this might be achieved using [appveyor](appveyor.com) via https://github.com/krlmlr/r-appveyor/, but I haven't investigated).

There's one issue: the bsseq vignette is failing under `R CMD check`. I can't quite figure this out - I have no problems when checking the vignette on my mac. You can see this for yourself by removing the `r_check_args: "--no-vignettes"` in the `.travis.yml` and re-running Travis.

The PR also adds test coverage checking with https://codecov.io/ and Travis integration via [covr](https://github.com/jimhester/covr).

You'll need to allow Travis and codecov access to bsseq via their respective websites.