### PR TITLE
Return all objects from fstat.pipeline()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bsseq
-Version: 1.7.4
+Version: 1.7.5
 Title: Analyze, manage and store bisulfite sequencing data
 Description: A collection of tools for analyzing and visualizing bisulfite
     sequencing data.

--- a/R/BSmooth.fstat.R
+++ b/R/BSmooth.fstat.R
@@ -161,5 +161,5 @@ fstat.pipeline <- function(BSseq, design, contrasts, cutoff, fac, nperm = 1000,
     meth <- t(apply(meth, 1, function(xx) tapply(xx, fac, mean)))
     dmrs <- cbind(dmrs, meth)
     dmrs$maxDiff <- rowMaxs(meth) - rowMins(meth)
-    dmrs
+    list(bstat = bstat, dmrs = dmrs, idxMatrix = idxMatrix, nullDist = nullDist)
 }


### PR DESCRIPTION
Previously was only returning `dmrs`, which didn't allow plotting of the results.