### PR TITLE
Fix bug in read.bismark() reported by Winston Timp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bsseq
-Version: 1.7.5
+Version: 1.7.6
 Title: Analyze, manage and store bisulfite sequencing data
 Description: A collection of tools for analyzing and visualizing bisulfite
     sequencing data.

--- a/R/combine.R
+++ b/R/combine.R
@@ -79,7 +79,7 @@ combineList <- function(x, ...) {
         Cov <- do.call(cbind, lapply(x, function(xx) getBSseq(xx, "Cov")))
     } else {
         gr <- sort(reduce(do.call(c, unname(lapply(x, granges))), min.gapwidth = 0L))
-        sampleNames <- do.call(c, lapply(x, sampleNames))
+        sampleNames <- do.call(c, unname(lapply(x, sampleNames)))
         M <- matrix(0, ncol = length(sampleNames), nrow = length(gr))
         colnames(M) <- sampleNames
         Cov <- M

--- a/R/read.bismark.R
+++ b/R/read.bismark.R
@@ -13,7 +13,7 @@ read.bismark <- function(files,
     }
     fileType <- match.arg(fileType)
     if (verbose) {
-        message(paste0("Assuming file type is", fileType))
+        message(paste0("Assuming file type is ", fileType))
     }
     ## Process each file
     idxes <- seq_along(files)


### PR DESCRIPTION
After digging deep down the rabbit hole it turned out that non-NULL `names()` on `sampleNames` broke a check in `SummarizedExperiment()` constructor. Specifically, https://github.com/Bioconductor-mirror/SummarizedExperiment/blob/master/R/RangedSummarizedExperiment-class.R#L130, where this call to `identical()` returned FALSE because while the values were identical, one vector had non-NULL `names()` while the other had NULL `names()`.