### PR TITLE
Minor read.bismark() improvements:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bsseq
-Version: 1.7.9
+Version: 1.7.10
 Title: Analyze, manage and store bisulfite sequencing data
 Description: A collection of tools for analyzing and visualizing bisulfite
     sequencing data.

--- a/inst/unitTests/test_read.bismark.R
+++ b/inst/unitTests/test_read.bismark.R
@@ -9,6 +9,15 @@ test_read.bismark_coverage <- function() {
                           fileType = "cov",
                           verbose = FALSE)
     checkTrue(is(bsseq, "BSseq"))
+    # Regression check
+    # Should not fail if sampleNames have names()
+    bsseq <- read.bismark(files = infile,
+                          sampleNames = c(test = "test_data"),
+                          rmZeroCov = FALSE,
+                          strandCollapse = FALSE,
+                          fileType = "cov",
+                          verbose = FALSE)
+    checkTrue(is(bsseq, "BSseq"))
 
     # Should also work because the "cov" fileType is the same as the
     # "oldBedGraph" fileType

--- a/man/read.bismark.Rd
+++ b/man/read.bismark.Rd
@@ -11,6 +11,7 @@
              rmZeroCov = FALSE,
              strandCollapse = TRUE,
              fileType = c("cov", "oldBedGraph", "cytosineReport"),
+             mc.cores = 1,
              verbose = TRUE)
 }
 \arguments{
@@ -22,8 +23,13 @@
     all samples be removed. This will result in a much smaller object if
     the data originates from (targeted) capture bisulfite sequencing.}
   \item{strandCollapse}{Should strand-symmetric methylation loci, e.g., CpGs,
-    be collapsed across strands.}
+    be collapsed across strands. This option is only available if
+    \code{fileType = "cytosineReport"} since the other file types do not
+    contain the necessary strand information.}
   \item{fileType}{The format of the input file; see Note for details.}
+  \item{mc.cores}{The number of cores used.  Note that setting
+    \code{mc.cores} to a value greater than 1 is not  supported on MS
+    Windows, see the help page for \code{mclapply}.}
   \item{verbose}{Make the function verbose.}
 }
 \note{
@@ -96,7 +102,7 @@
   bismarkBSseq <- read.bismark(files = infile,
                                sampleNames = "test_data",
                                rmZeroCov = FALSE,
-                               strandCollapse = TRUE,
+                               strandCollapse = FALSE,
                                fileType = "cov",
                                verbose = TRUE)
   bismarkBSseq


### PR DESCRIPTION
- read files in parallel via `mclapply()` (free speedup)
- Error if user tries to collapse-by-strand the strand-less `.cov` input files (addresses https://jhu-genomics.slack.com/archives/hansen_bsseq/p1460559072000077)
- Strip `names()` from `sampleNames` to avoid failing strict SummarizedExperiment validity checks (further tightening of https://github.com/kasperdanielhansen/bsseq/pull/16/files)
- Pass `rmZeroCov` to `read.bismarkCytosineReportRaw()` (not sure how this was overlooked)
- Documentation and example updates (in light of above)