### PR TITLE
Check length of lwd plotting param in .bsGetCol

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -160,8 +160,8 @@ plotManyRegions <- function(BSseq, regions = NULL, extend = 0, main = "", addReg
         else
             lwd <- rep(1, nrow(pData(object)))
     }
-    if(length(lty) != ncol(object))
-        lty <- rep(lty, length.out = ncol(object))
+    if(length(lwd) != ncol(object))
+        lwd <- rep(lwd, length.out = ncol(object))
     if(is.null(names(lwd)))
         names(lwd) <- sampleNames(object)
 


### PR DESCRIPTION
Check length of lwd plotting param after extracting from pData using the .bsGetCol function to make sure it is the same as the number of rows in pData.  Previously duplicated lines 152-153 (checking length of lty plotting param).