### PR TITLE
Changes due to renaming in DelayedArray package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bsseq
-Version: 1.11.1
+Version: 1.11.2
 Encoding: UTF-8
 Title: Analyze, manage and store bisulfite sequencing data
 Description: A collection of tools for analyzing and visualizing bisulfite

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -35,8 +35,7 @@ importFrom(R.utils, "isGzipped", "gunzip")
 import(limma)
 importFrom(permute, "shuffleSet", "how")
 importClassesFrom(DelayedArray, "DelayedArray", "DelayedMatrix")
-importFrom(DelayedArray, "DelayedArray", "plogis", "pmin2", "pmax2",
-           "setRealizeBackend", "type")
+importFrom(DelayedArray, "DelayedArray", "plogis", "pmin2", "pmax2")
 
 ##
 ## Exporting

--- a/man/BSseq-class.Rd
+++ b/man/BSseq-class.Rd
@@ -134,7 +134,7 @@ slots for representing smoothed data. This class is an extension of
       matrices (the latter two can only be combined if all objects have the
       same rowRanges). The default, \code{BACKEND = NULL}, corresponds to using
       \link[base]{matrix} objects. See
-      \code{?DelayedArray::\link[DelayedArray]{setRealizeBackend}} for
+      \code{?DelayedArray::\link[DelayedArray]{setRealizationBackend}} for
       alternative backends.
       }
 

--- a/man/read.bismark.Rd
+++ b/man/read.bismark.Rd
@@ -32,10 +32,10 @@
     \code{mc.cores} to a value greater than 1 is not  supported on MS
     Windows, see the help page for \code{mclapply}.}
   \item{verbose}{Make the function verbose.}
-  \item{BACKEND}{Which backend should be used for the 'M' and 'Cov' matrices?
-    The default, \code{NULL}, corresponds to using \link[base]{matrix}
-    objects. See \code{?DelayedArray::\link[DelayedArray]{setRealizeBackend}}
-    for alternative backends.}
+  \item{BACKEND}{The backend used for the 'M' and 'Cov' matrices. The default,
+  \code{NULL}, corresponds to using \link[base]{matrix} objects. See
+    \code{?DelayedArray::\link[DelayedArray]{setRealizationBackend}} for
+    alternative backends.}
 }
 \note{
   Input files can either be gzipped or not.
@@ -118,7 +118,7 @@
   # An example constructing a HDF5Array-backed BSseq object
   #
   library(HDF5Array)
-  # See ?DelayedArray::setRealizeBackend for details
+  # See ?DelayedArray::setRealizationBackend for details
   hdf5_bismarkBSseq <- read.bismark(files = infile,
                                     sampleNames = "test_data",
                                     rmZeroCov = FALSE,


### PR DESCRIPTION
Keeping up with renaming.
FYI: the 1 warning in `R CMD check` is due to clash of `matrixStats::rowRanges` and `SummarizedExperiment::rowRanges` but that needs to be fixed in SummarizedExperiment not here