### PR TITLE
fixed bug in combineList that lead to incorrect assignment of meth va…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bsseq
-Version: 1.13.4
+Version: 1.13.5
 Encoding: UTF-8
 Title: Analyze, manage and store bisulfite sequencing data
 Description: A collection of tools for analyzing and visualizing bisulfite


### PR DESCRIPTION
I noticed that after combining BSseq objects with combineList, the methylation values from the original genomic ranges were not assigned correctly to the ranges in the final combined object. I found the bug that was causing these swaps and I am proposing a fix. Below is the code I used for testing, in version 1.13.4 it returns FALSE (i.e. jumbling), in the fix version I am proposing it returns TRUE.

library(bsseq)
M <- matrix(0:8, 3, 3)
Cov <- matrix(1:9, 3, 3)

BS1 <- BSseq(chr = c("chr1", "chr2", "chr1"),
             pos = c(1,2,3), M = M,
             Cov = Cov, sampleNames = c("A","B", "C"))
BS2 <- BSseq(chr = c("chr2", "chr1", "chr2"),
             pos = c(1,2,3), M = M,
             Cov = Cov, sampleNames = c("D","E", "F"))
combined <- combineList( list( BS1, BS2 ) )
over <- findOverlaps( rowRanges( BS2 ), rowRanges( combined ), type="equal")
methAlone <- getMeth( BS2[queryHits( over ),c("D", "E", "F")], type="raw" )
methCombined <- getMeth( combined[subjectHits( over ),c("D", "E", "F")], type="raw" )
all(methAlone == methCombined)