### PR TITLE
Fix speed regression in BSmooth()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: bsseq
-Version: 1.13.5
+Version: 1.13.6
 Encoding: UTF-8
 Title: Analyze, manage and store bisulfite sequencing data
 Description: A collection of tools for analyzing and visualizing bisulfite


### PR DESCRIPTION
Use pmin()/pmax() instead of pmin2()/pmax2() in BSmooth()
Faster to realise as array and use pmin()/pmax() than to use pmin2()/pmax2() on DelayedArray and then realise as array. No real penalty since have to load this data into memory anyway in order to smooth